### PR TITLE
Return a non-zero exit code when do not have enough memory.

### DIFF
--- a/hapcut-src/hapcut.c
+++ b/hapcut-src/hapcut.c
@@ -233,12 +233,12 @@ int main(int argc, char** argv)
 		if (VCFformat ==1) 
 		{
 			fprintf(stderr,"\n\nfragment file: %s\nvariantfile (VCF format):%s\nhaplotypes will be output to file: %s\niterations of maxcut algorithm: %d\nQVoffset: %d\n\n",fragfile,VCFfile,hapfile,maxiter,QVoffset); 	
-			maxcut_haplotyping(fragfile,VCFfile,0,hapfile,maxiter); 
+			if (maxcut_haplotyping(fragfile,VCFfile,0,hapfile,maxiter) < 0) return -1; 
 		}
 		else 
 		{
 			fprintf(stderr,"\n\nfragment file: %s\nvariantfile (variant format):%s\nhaplotypes will be output to file: %s\niterations of maxcut algorithm: %d\nQVoffset: %d\n\n",fragfile,varfile,hapfile,maxiter,QVoffset); 	
-			maxcut_haplotyping(fragfile,varfile,0,hapfile,maxiter); 
+			if (return maxcut_haplotyping(fragfile,varfile,0,hapfile,maxiter) < 0) return -1; 
 		}
 	}
 	return 0;


### PR DESCRIPTION
@vibansal this caused downstream processes to run even though there was a failure with hapcut.  The tool should return a non-zero error code in the case of failure.  This fixes the case I ran into (not enough memory).
